### PR TITLE
Fix issue with ListView initial index w/ switch to FlatList

### DIFF
--- a/lib/FullScreenContainer.js
+++ b/lib/FullScreenContainer.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import {
   DeviceEventEmitter,
   Dimensions,
-  ListView,
+  FlatList,
   View,
   ViewPagerAndroid,
   StyleSheet,
@@ -20,18 +20,17 @@ export default class FullScreenContainer extends React.Component {
 
   static propTypes = {
     style: View.propTypes.style,
-    dataSource: PropTypes.instanceOf(ListView.DataSource).isRequired,
     mediaList: PropTypes.array.isRequired,
     /*
      * opens grid view
      */
     onGridButtonTap: PropTypes.func,
-  
+
     /*
      * Display top bar
      */
     displayTopBar: PropTypes.bool,
-  
+
     /*
      * updates top bar title
      */
@@ -79,7 +78,7 @@ export default class FullScreenContainer extends React.Component {
   constructor(props, context) {
     super(props, context);
 
-    this._renderRow = this._renderRow.bind(this);
+    this._renderItem = this._renderItem.bind(this);
     this._toggleControls = this._toggleControls.bind(this);
     this._onScroll = this._onScroll.bind(this);
     this._onPageSelected = this._onPageSelected.bind(this);
@@ -105,15 +104,15 @@ export default class FullScreenContainer extends React.Component {
   }
 
   openPage(index, animated) {
-    if (!this.scrollView) {
+    if (!this.flatListView) {
       return;
     }
 
     if (Platform.OS === 'ios') {
       const screenWidth = Dimensions.get('window').width;
-      this.scrollView.scrollTo({
-        x: index * screenWidth,
-        animated,
+      this.flatListView.scrollToIndex({
+        index: index,
+        animated: animated,
       });
     } else {
       this.scrollView.setPageWithoutAnimation(index);
@@ -214,7 +213,7 @@ export default class FullScreenContainer extends React.Component {
     }
   }
 
-  _renderRow(media: Object, sectionID: number, rowID: number) {
+  _renderItem(item) {
     const {
       displaySelectionButtons,
       onMediaSelection,
@@ -222,20 +221,20 @@ export default class FullScreenContainer extends React.Component {
     } = this.props;
 
     return (
-      <View key={`row_${rowID}`} style={styles.flex}>
+      <View style={styles.flex}>
         <TouchableWithoutFeedback
           onPress={this._toggleControls}
           onLongPress={this.props.onPhotoLongPress}
           delayLongPress={this.props.delayLongPress}>
           <Photo
-            ref={ref => this.photoRefs[rowID] = ref}
+            ref={ref => this.photoRefs[item.index] = ref}
             lazyLoad
             useCircleProgress={useCircleProgress}
-            uri={media.photo}
+            uri={item.item.photo}
             displaySelectionButtons={displaySelectionButtons}
-            selected={media.selected}
+            selected={item.item.selected}
             onSelection={(isSelected) => {
-              onMediaSelection(rowID, isSelected);
+              onMediaSelection(item.index, isSelected);
             }}
           />
         </TouchableWithoutFeedback>
@@ -243,8 +242,12 @@ export default class FullScreenContainer extends React.Component {
     );
   }
 
+  getItemLayout = (data, index) => (
+    { length: Dimensions.get('window').width, offset: Dimensions.get('window').width * index, index }
+  )
+
   _renderScrollableContent() {
-    const { dataSource, mediaList } = this.props;
+    const { mediaList } = this.props;
 
     if (Platform.OS === 'android') {
       return (
@@ -253,26 +256,31 @@ export default class FullScreenContainer extends React.Component {
           ref={scrollView => this.scrollView = scrollView}
           onPageSelected={this._onPageSelected}
         >
-          {mediaList.map((child, idx) => this._renderRow(child, 0, idx))}
+          {mediaList.map((child, idx) => this._renderItem({'item':child, 'index':idx}))}
         </ViewPagerAndroid>
       );
     }
 
     return (
-      <ListView
-        ref={scrollView => this.scrollView = scrollView}
-        dataSource={dataSource}
-        renderRow={this._renderRow}
+      <FlatList
+        ref={flatListView => this.flatListView = flatListView}
+        data={mediaList}
+        renderItem={this._renderItem}
         onScroll={this._onScroll}
+        keyExtractor={this._keyExtractor}
         horizontal
         pagingEnabled
         showsHorizontalScrollIndicator={false}
         showsVerticalScrollIndicator={false}
         directionalLockEnabled
         scrollEventThrottle={16}
+        getItemLayout={this.getItemLayout}
+        initialScrollIndex={this.state.currentIndex}
       />
     );
   }
+
+  _keyExtractor = (item, index) => index;
 
   render() {
     const {


### PR DESCRIPTION
Fix issue with ListView initial index not working on iOS due to "contentOffset" bug. 
ListView is no longer supported, so switch to FlatList where the issue is fixed.

Repro:
1) Create Viewer and set initialIndex to a non-zero value. After the viewer loads try swiping left or right. Notice the number at the top resets to 0. Also notice that the image doesn't load correctly.